### PR TITLE
Move Sparks into separate group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.settings
+.classpath
+.project
+gen
+bin

--- a/src/net/phfactor/meltdown/GroupsActivity.java
+++ b/src/net/phfactor/meltdown/GroupsActivity.java
@@ -24,28 +24,28 @@ import android.widget.ListView;
 import android.widget.Toast;
 import android.widget.TwoLineListItem;
 
-public class GroupsActivity extends ListActivity 
+public class GroupsActivity extends ListActivity
 {
 	static final String TAG = "MeltdownGA";
-    /**
-     * Custom list adapter that fits our rss data into the list.
-     */
-    private GroupListAdapter mAdapter;
+	/**
+	 * Custom list adapter that fits our rss data into the list.
+	 */
+	private GroupListAdapter mAdapter;
 	private dBroadcastCatcher catcher;
 	private IntentFilter ifilter;
 	private MeltdownApp app;
-	ProgressDialog pd;
-	
+	private ProgressDialog pd;
+
 	private int last_pos;
-	
+
 	@Override
-	public void onCreate(Bundle savedInstanceState) 
+	public void onCreate(Bundle savedInstanceState)
 	{
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.list);
 		getActionBar().setSubtitle("Starting up...");
 		last_pos = 0;
-		
+
 		catcher = new dBroadcastCatcher();
 		ifilter = new IntentFilter();
 		ifilter.addAction(Downloader.ACTION_UPDATING_GROUPS);
@@ -57,12 +57,12 @@ public class GroupsActivity extends ListActivity
 		ifilter.addAction(Downloader.ACTION_UPDATE_STARTING);
 		ifilter.addAction(Downloader.ACTION_UPDATE_DONE);
 	}
-	
+
 	@Override
 	protected void onPause()
 	{
 		super.onPause();
-		LocalBroadcastManager.getInstance(this).unregisterReceiver(catcher);		
+		LocalBroadcastManager.getInstance(this).unregisterReceiver(catcher);
 		Log.d(TAG, "Groups just got paused, doing GC sweep of items");
 		app.sweepReadItems();
 	}
@@ -72,7 +72,7 @@ public class GroupsActivity extends ListActivity
 	{
 		super.onResume();
 		app = (MeltdownApp) getApplication();
-		
+
 		// Run setup if login errors out
 		if (app.isAppConfigured() == false)
 		{
@@ -80,10 +80,10 @@ public class GroupsActivity extends ListActivity
 			Toast.makeText(this, "Please configure your server", Toast.LENGTH_SHORT).show();
 			return;
 		}
-		
+
 		app.sweepReadItems();
 		LocalBroadcastManager.getInstance(this).registerReceiver(catcher, ifilter);
-	
+
 		doRefresh();
 	}
 
@@ -92,20 +92,20 @@ public class GroupsActivity extends ListActivity
 		getActionBar().setSubtitle(app.totalUnreadItems() + " to read");
 		mAdapter = new GroupListAdapter(GroupsActivity.this, app.getUnreadGroups());
 		setListAdapter(mAdapter);
-        final ListView lv = getListView();
-        
-        // FIXME As in the ItemsActivity, figure out the next group to read and position _there_
-        if (last_pos > 0)
-        	last_pos = Math.min(last_pos, lv.getCount());
-        lv.setSelection(last_pos);
+		final ListView lv = getListView();
 
-        lv.setOnItemClickListener(new OnItemClickListener()
-        {
-        	@Override
-        	public void onItemClick(AdapterView<?> arg0, View view, int pos, long id)
-        	{
+		// FIXME As in the ItemsActivity, figure out the next group to read and position _there_
+		if (last_pos > 0)
+			last_pos = Math.min(last_pos, lv.getCount());
+		lv.setSelection(last_pos);
+
+		lv.setOnItemClickListener(new OnItemClickListener()
+		{
+			@Override
+			public void onItemClick(AdapterView<?> arg0, View view, int pos, long id)
+			{
 				RssGroup group = (RssGroup) lv.getItemAtPosition(pos);
-				
+
 				Intent intent = new Intent(GroupsActivity.this, ItemsActivity.class);
 				Bundle bundle = new Bundle();
 				bundle.putString("title", group.title);
@@ -116,77 +116,77 @@ public class GroupsActivity extends ListActivity
 				// http://stackoverflow.com/questions/2628741/listview-and-scroll
 				last_pos = pos;
 				startActivity(intent);
-        	}		        	
-        });
+			}
+		});
 	}
-	
+
 	/**
-     * ArrayAdapter encapsulates a java.util.List of T, for presentation in a
-     * ListView. This subclass specializes it to hold RssItems and display
-     * their title/description data in a TwoLineListItem.
-     */
-    private class GroupListAdapter extends ArrayAdapter<RssGroup> 
-    {
-        private LayoutInflater mInflater;
+	 * ArrayAdapter encapsulates a java.util.List of T, for presentation in a
+	 * ListView. This subclass specializes it to hold RssItems and display
+	 * their title/description data in a TwoLineListItem.
+	 */
+	private class GroupListAdapter extends ArrayAdapter<RssGroup>
+	{
+		private LayoutInflater mInflater;
 
-        public GroupListAdapter(Context context, List<RssGroup> objects) 
-        {
-            super(context, 0, objects);
-            mInflater = (LayoutInflater)context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-        }
+		public GroupListAdapter(Context context, List<RssGroup> objects)
+		{
+			super(context, 0, objects);
+			mInflater = (LayoutInflater)context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+		}
 
-        /**
-         * This is called to render a particular item for the on screen list.
-         * Uses an off-the-shelf TwoLineListItem view, which contains text1 and
-         * text2 TextViews. We pull data from the RssItem and set it into the
-         * view. The convertView is the view from a previous getView(), so
-         * we can re-use it.
-         * 
-         * @see ArrayAdapter#getView
-         */
-        @Override
-        public View getView(int position, View convertView, ViewGroup parent) 
-        {
-            TwoLineListItem view;
+		/**
+		 * This is called to render a particular item for the on screen list.
+		 * Uses an off-the-shelf TwoLineListItem view, which contains text1 and
+		 * text2 TextViews. We pull data from the RssItem and set it into the
+		 * view. The convertView is the view from a previous getView(), so
+		 * we can re-use it.
+		 * 
+		 * @see ArrayAdapter#getView
+		 */
+		@Override
+		public View getView(int position, View convertView, ViewGroup parent)
+		{
+			TwoLineListItem view;
 
-            // Here view may be passed in for re-use, or we make a new one.
-            if (convertView == null) 
-            {
-                view = (TwoLineListItem) mInflater.inflate(android.R.layout.simple_list_item_2,
-                        null);
-            } else 
-            {
-                view = (TwoLineListItem) convertView;
-            }
+			// Here view may be passed in for re-use, or we make a new one.
+			if (convertView == null)
+			{
+				view = (TwoLineListItem) mInflater.inflate(android.R.layout.simple_list_item_2,
+						null);
+			} else
+			{
+				view = (TwoLineListItem) convertView;
+			}
 
-            // FIXME race condition
-            RssGroup grp = app.getUnreadGroups().get(position);
+			// FIXME race condition
+			RssGroup grp = app.getUnreadGroups().get(position);
 
-            // TODO Move strings into strings.xml
-            // Set the item title and description into the view.
-            view.getText1().setText(grp.title);
-            int unread_count = app.groupUnreadItems(grp.id);
-            String descr = "";
-            if (unread_count == 0)
-            	descr = " -- No unread items --";
-            else if (unread_count == 1)
-            	descr = "One unread item";
-            else
-            	descr = String.format(Locale.ENGLISH, "%d unread items", unread_count);
-            view.getText2().setText(descr);
-            
-            // Simulate zebra-striping - a touch of class. Maybe. Need to consider themes.
-            //if (position % 2 == 0)
-            //	view.setBackgroundColor(Color.LTGRAY);
-                        
-            return view;
-        }
-    }
-	
-    // Catch updates from the Service, update the data adapter. Needs more work.
-    // See http://www.intertech.com/Blog/Post/Using-LocalBroadcastManager-in-Service-to-Activity-Communications.aspx
-    private class dBroadcastCatcher extends BroadcastReceiver
-    {
+			// TODO Move strings into strings.xml
+			// Set the item title and description into the view.
+			view.getText1().setText(grp.title);
+			int unread_count = app.groupUnreadItems(grp.id);
+			String descr = "";
+			if (unread_count == 0)
+				descr = " -- No unread items --";
+			else if (unread_count == 1)
+				descr = "One unread item";
+			else
+				descr = String.format(Locale.ENGLISH, "%d unread items", unread_count);
+			view.getText2().setText(descr);
+
+			// Simulate zebra-striping - a touch of class. Maybe. Need to consider themes.
+			//if (position % 2 == 0)
+			//	view.setBackgroundColor(Color.LTGRAY);
+
+			return view;
+		}
+	}
+
+	// Catch updates from the Service, update the data adapter. Needs more work.
+	// See http://www.intertech.com/Blog/Post/Using-LocalBroadcastManager-in-Service-to-Activity-Communications.aspx
+	private class dBroadcastCatcher extends BroadcastReceiver
+	{
 		@Override
 		public void onReceive(Context context, Intent intent)
 		{
@@ -205,10 +205,10 @@ public class GroupsActivity extends ListActivity
 			else if (pd != null)
 				pd.setMessage(intent.getAction());
 		}
-    }
-    
+	}
+
 	@Override
-	public boolean onOptionsItemSelected(MenuItem item) 
+	public boolean onOptionsItemSelected(MenuItem item)
 	{
 		switch (item.getItemId())
 		{
@@ -220,7 +220,7 @@ public class GroupsActivity extends ListActivity
 		case R.id.menu_setup_post:
 			Log.d(TAG, "Post URL setup time");
 			startActivity(new Intent(this, SetupPostURL.class));
-			return true;			
+			return true;
 		case R.id.menu_settings:
 			Log.d(TAG, "Settings selecected");
 			startActivity(new Intent(this, SetupServerActivity.class));
@@ -233,7 +233,7 @@ public class GroupsActivity extends ListActivity
 	}
 
 	@Override
-	public boolean onCreateOptionsMenu(Menu menu) 
+	public boolean onCreateOptionsMenu(Menu menu)
 	{
 		getMenuInflater().inflate(R.menu.activity_groups, menu);
 		return true;

--- a/src/net/phfactor/meltdown/MeltdownApp.java
+++ b/src/net/phfactor/meltdown/MeltdownApp.java
@@ -31,6 +31,7 @@ public class MeltdownApp extends Application
 	static final String FIRST_RUN = "first_run";
 	
 	static final int ORPHAN_ID = 8675309;
+	static final int SPARKS_ID = 8675310;
 	
 	private List<RssGroup> groups;
 	private List<RssFeed> feeds;
@@ -382,6 +383,8 @@ public class MeltdownApp extends Application
 		
 		RssGroup orphans = new RssGroup("Orphaned feeds", ORPHAN_ID);		
 		this.groups.add(orphans);
+		RssGroup sparks = new RssGroup("Sparks", SPARKS_ID);		
+		this.groups.add(sparks);
 		
 		startUpdates();
 		Log.i(TAG, "App init completed.");
@@ -594,8 +597,14 @@ public class MeltdownApp extends Application
 		RssGroup group = findGroupForItem(item);
 		if (group == null)
 		{
-			Log.d(TAG, "Orphan item! No group found for post ID " + item.id + " " + item.title);
-			group = findGroupById(ORPHAN_ID);
+			RssFeed feed = findFeedById(item.feed_id);
+			if (feed.is_spark) {
+				Log.d(TAG, "Spark found for post ID " + item.id + " " + item.title);
+				group = findGroupById(SPARKS_ID);
+			} else {
+				Log.d(TAG, "Orphan item! No group found for post ID " + item.id + " " + item.title);
+				group = findGroupById(ORPHAN_ID);
+			}
 		}
 		
 		// DDT

--- a/src/net/phfactor/meltdown/MeltdownApp.java
+++ b/src/net/phfactor/meltdown/MeltdownApp.java
@@ -19,8 +19,8 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.os.SystemClock;
 import android.util.Log;
 
-public class MeltdownApp extends Application 
-{	
+public class MeltdownApp extends Application
+{
 	static final String TAG = "MeltdownApp";
 
 	static final String DATABASE = "items.db";
@@ -29,32 +29,32 @@ public class MeltdownApp extends Application
 	static final String C_HTML = "html";
 
 	static final String FIRST_RUN = "first_run";
-	
+
 	static final int ORPHAN_ID = 8675309;
 	static final int SPARKS_ID = 8675310;
-	
+
 	private List<RssGroup> groups;
 	private List<RssFeed> feeds;
 	private List<Favicon> icons;
-	
+
 	private long last_refresh_time;
 	private Boolean login_verified;
-	
+
 	private PendingIntent pendingIntent;
-	
+
 	private RestClient xcvr;
 	private ConfigFile configFile;
-	
+
 	public MeltdownApp()
 	{
 		super();
 	}
-	
+
 	/* Sweep disk files and remove any not present in the in-memory items array
 	 * 
 	 */
 	protected void sweepDiskCache()
-	{		
+	{
 		String[] filenames = fileList();
 		for (int idx = 0; idx < filenames.length; idx++)
 		{
@@ -69,20 +69,20 @@ public class MeltdownApp extends Application
 			}
 		}
 	}
-	
+
 	public String getAppVersion()
 	{
 		PackageInfo pinfo;
 		try {
 			pinfo = getPackageManager().getPackageInfo(getPackageName(), 0);
-		} catch (NameNotFoundException e) 
+		} catch (NameNotFoundException e)
 		{
 			e.printStackTrace();
 			return "unknown";
 		}
 		return "Version " + pinfo.versionName + " build " + pinfo.versionCode;
 	}
-	
+
 	//As with the parseFeedsGroups, this is retured as a comma-delimited string we have to parse.
 	private List<Integer> fetchUnreadItemsIDs()
 	{
@@ -92,14 +92,14 @@ public class MeltdownApp extends Application
 		{
 			jdata = new JSONObject(xcvr.fetchUnreadList());
 			String array_str = jdata.getString("unread_item_ids");
-			return parseStrArray(array_str); 
+			return parseStrArray(array_str);
 		} catch (JSONException je)
 		{
 			Log.e(TAG, "Error parsing list of unread item IDs");
 		}
 		return rc;
 	}
-	
+
 	/*
 	 * Given an items' filename in the format "%d.post", return the %d
 	 */
@@ -107,24 +107,24 @@ public class MeltdownApp extends Application
 	{
 		if (filename == null)
 			return -1;
-		
+
 		String delims = "[.]";
 		String[] tokens = filename.split(delims);
 		if (tokens.length == 2)
 		{
 			try
 			{
-				return (Integer.parseInt(tokens[0]));				
+				return (Integer.parseInt(tokens[0]));
 			} catch (NumberFormatException nfe)
 			{
 				return -1;
 			}
 		}
-		
+
 		Log.e(TAG, "Unable to parse " + filename);
 		return -1;
 	}
-	
+
 	protected RssFeed findFeedById(int feed_id)
 	{
 		for (int idx =0; idx < feeds.size(); idx++)
@@ -134,7 +134,7 @@ public class MeltdownApp extends Application
 		}
 		return null;
 	}
-	
+
 	/*
 	 *  Reverse index methods - find group, feed or post by numeric ID.
 	 */
@@ -147,7 +147,7 @@ public class MeltdownApp extends Application
 		}
 		return null;
 	}
-	
+
 	// Similar - locate a group object by title string
 	protected RssGroup findGroupByName(String name)
 	{
@@ -158,16 +158,16 @@ public class MeltdownApp extends Application
 		}
 		return null;
 	}
-	
+
 	RssGroup findGroupForItem(RssItem item)
 	{
 		if (item == null)
 			return null;
-		
+
 		RssFeed feed = findFeedById(item.feed_id);
 		if (feed == null)
 			return null;
-		
+
 		if (feed.groups.size() == 0)
 		{
 			Log.e(TAG, "Feed " + feed.title + " has no group!");
@@ -175,7 +175,7 @@ public class MeltdownApp extends Application
 		}
 		else if (feed.groups.size() > 1)
 			Log.d(TAG, "Feed " + feed.title + " has " + feed.groups.size() + " group(s)");
-		
+
 		return findGroupById(feed.groups.get(0));
 	}
 
@@ -188,7 +188,7 @@ public class MeltdownApp extends Application
 		}
 		return null;
 	}
-	
+
 	protected RssItem findPostById(int post_id)
 	{
 		for (int grp_idx = 0; grp_idx < groups.size(); grp_idx++)
@@ -202,7 +202,7 @@ public class MeltdownApp extends Application
 		}
 		return null;
 	}
-	
+
 	// How many cache files are present? Just used by about page.
 	protected int getFileCount()
 	{
@@ -215,7 +215,7 @@ public class MeltdownApp extends Application
 		}
 		return count;
 	}
-	
+
 	// How many feeds?
 	protected int getFeedCount()
 	{
@@ -245,7 +245,7 @@ public class MeltdownApp extends Application
 		for (int idx = 0; idx < groups.size(); idx++)
 			rc += groupUnreadItems(groups.get(idx));
 		return rc;
-	}	
+	}
 
 	public List<RssGroup> getUnreadGroups()
 	{
@@ -258,16 +258,16 @@ public class MeltdownApp extends Application
 		}
 		return rc;
 	}
-	
+
 	public int groupUnreadItems(RssGroup group)
 	{
 		int count = 0;
 		for (int idx = 0; idx < group.items.size(); idx++)
 			if (group.items.get(idx).is_read == false)
 				count++;
-		return count;		
+		return count;
 	}
-	
+
 	public int groupUnreadItems(int group_id)
 	{
 		RssGroup group = findGroupById(group_id);
@@ -276,30 +276,30 @@ public class MeltdownApp extends Application
 
 		return groupUnreadItems(group);
 	}
-		
+
 	// Is the app setup and verified?
 	// FIXME distinguish offline from unconfigured ya moron!!
 	public Boolean isAppConfigured()
 	{
 		if (!configFile.haveConfigInfo())
 			return false;
-		
+
 		if (login_verified)
 			return true;
-		
+
 		// Need to recreate the RestClient, as it caches the API URL.
 		xcvr = new RestClient(configFile.getToken(), configFile.getAPIUrl());
-		
+
 		login_verified = xcvr.verifyLogin();
 		return login_verified;
 	}
-	
+
 	// Call the users' post hook
 	protected void callUserURL(String url)
 	{
 		xcvr.callUserURL(url);
 	}
-	
+
 	// Iterate over a group, and mark all of the items in it as read. One API call and then local cleanup.
 	protected void markGroupRead(int group_id)
 	{
@@ -309,17 +309,17 @@ public class MeltdownApp extends Application
 			Log.e(TAG, "Unable to locate group " + group_id);
 			return;
 		}
-	
+
 		Log.d(TAG, "Starting to mark group " + grp.title + " as read");
 		xcvr.markGroupRead(group_id, last_refresh_time);
-	
+
 		for (int idx = 0; idx < grp.items.size(); idx++)
 		{
 			grp.items.get(idx).is_read = true;
 		}
 		sweepReadFromGroup(grp);
 	}
-	
+
 	// Mark some thread read in a group matching a given title.
 	// Use case is long-running threads in RSS feeds from WatchUSeek and similar.
 	protected int markGroupThreadRead(int group_id, String title)
@@ -331,7 +331,7 @@ public class MeltdownApp extends Application
 			Log.e(TAG, "Unable to locate group " + group_id);
 			return 0;
 		}
-	
+
 		for (int idx = 0; idx < grp.items.size(); idx++)
 		{
 			RssItem item = grp.items.get(idx);
@@ -344,27 +344,27 @@ public class MeltdownApp extends Application
 		sweepReadItems();
 		return rm_count;
 	}
-	
+
 	// Mark an item/post as read, both locally and on the server.
 	public synchronized void markItemRead(int item_id)
 	{
 		// Get the server update running in the background
 		xcvr.markItemRead(item_id);
-		
+
 		RssItem item = findPostById(item_id);
 		if (item != null)
-			item.is_read = true;			
+			item.is_read = true;
 	}
-	
+
 	public synchronized void markItemSaved(int item_id)
 	{
 		xcvr.markItemSaved(item_id);
-		
+
 		RssItem item = findPostById(item_id);
 		if (item != null)
-			item.is_saved = true;					
+			item.is_saved = true;
 	}
-	
+
 	@Override
 	public void onCreate()
 	{
@@ -373,23 +373,23 @@ public class MeltdownApp extends Application
 		Log.i(TAG, "App created, initializing");
 		last_refresh_time = 0L;
 		login_verified = false;
-	
+
 		this.feeds = new ArrayList<RssFeed>();
 		this.groups = new ArrayList<RssGroup>();
 		this.icons = new ArrayList<Favicon>();
-		
+
 		configFile = new ConfigFile(getApplicationContext());
-		xcvr = new RestClient(configFile.getToken(), configFile.getAPIUrl());		
-		
-		RssGroup orphans = new RssGroup("Orphaned feeds", ORPHAN_ID);		
+		xcvr = new RestClient(configFile.getToken(), configFile.getAPIUrl());
+
+		RssGroup orphans = new RssGroup("Orphaned feeds", ORPHAN_ID);
 		this.groups.add(orphans);
-		RssGroup sparks = new RssGroup("Sparks", SPARKS_ID);		
+		RssGroup sparks = new RssGroup("Sparks", SPARKS_ID);
 		this.groups.add(sparks);
-		
+
 		startUpdates();
 		Log.i(TAG, "App init completed.");
 	}
-	
+
 	/*
 	 * feeds groups and unread item ids are returned as CSV strings; common code to parse same.
 	 */
@@ -397,7 +397,7 @@ public class MeltdownApp extends Application
 	{
 		String[] nums = array_str.split(",");
 		List<Integer> rc = new ArrayList<Integer>();
-		
+
 		for (int idx = 0; idx < nums.length; idx++)
 		{
 			try {
@@ -408,9 +408,9 @@ public class MeltdownApp extends Application
 				Log.e(TAG, "Parse error, ignoring");
 			}
 		}
-		return rc;		
+		return rc;
 	}
-	
+
 	// At startup, load all of the items from disk, and reset max_ids before starting download from server.
 	// Called by the Downloader, as this takes minutes for 10k items on a nexus7.
 	private void reloadItemsFromDisk(List<Integer> new_items)
@@ -419,11 +419,11 @@ public class MeltdownApp extends Application
 		Long tzero = System.currentTimeMillis();
 		Long last_printf = System.currentTimeMillis();
 		Long notif_delta = 2000L;
-		
+
 		String[] files = fileList();
 		int fcount = 0;
 		Context ctx = getApplicationContext();
-		
+
 		for (int idx = 0; idx < files.length; idx++)
 		{
 			// Polish - display an update every couple seconds
@@ -432,9 +432,9 @@ public class MeltdownApp extends Application
 				last_printf = System.currentTimeMillis();
 				Log.d(TAG, " - at " + idx + " of " + files.length + " files");
 			}
-			
+
 			int post_id = filenameToInt(files[idx]);
-			
+
 			// Must be a valid ID and as-yet-unread
 			if ((post_id > 0) && (new_items.contains(post_id)))
 			{
@@ -444,24 +444,24 @@ public class MeltdownApp extends Application
 			}
 			else if (post_id > 0)
 				deleteFile(files[idx]);
-				
+
 		}
-		Log.d(TAG, files.length + " files processed, " + fcount + " loaded in " + 
-		((System.currentTimeMillis() - tzero) / 1000L) + " seconds");
+		Log.d(TAG, files.length + " files processed, " + fcount + " loaded in " +
+				((System.currentTimeMillis() - tzero) / 1000L) + " seconds");
 	}
-	
-	// Parse the results of the get-the-feeds API call into our simple array. 
+
+	// Parse the results of the get-the-feeds API call into our simple array.
 	// Note - overwrites the old without checking!
 	protected void saveFeedsData(String payload)
 	{
 		JSONArray jfeeds;
-		
+
 		if (payload == null)
 			return;
-		
+
 		// Erase the old feeds array and rebuild it with the servers' list
 		this.feeds = new ArrayList<RssFeed>();
-		
+
 		try
 		{
 			JSONObject jpayload = new JSONObject(payload);
@@ -469,15 +469,15 @@ public class MeltdownApp extends Application
 			this.last_refresh_time = jpayload.getLong("last_refreshed_on_time");
 			for (int idx = 0; idx < jfeeds.length(); idx++)
 				feeds.add(new RssFeed(jfeeds.getJSONObject(idx)));
-			
-		} catch (JSONException e) 
+
+		} catch (JSONException e)
 		{
 			e.printStackTrace();
 		}
 		Log.d(TAG, feeds.size() + " feeds found");
 	}
-	
-	// Feeds groups associate groups with the feeds they contain, so you can populate a group with feeds 
+
+	// Feeds groups associate groups with the feeds they contain, so you can populate a group with feeds
 	// and thence actual items.
 	private void saveFeedsGroupsData(JSONObject payload) throws JSONException
 	{
@@ -497,20 +497,20 @@ public class MeltdownApp extends Application
 	// Take the data returned from a groups fetch, parse and save into data model.
 	protected void saveGroupsData(String payload)
 	{
-		JSONArray jgroups;		
+		JSONArray jgroups;
 		RssGroup newGroup;
-		
+
 		if (payload == null)
 			return;
-		
+
 		try
 		{
-			JSONObject jsonPayload = new JSONObject(payload);			
+			JSONObject jsonPayload = new JSONObject(payload);
 			jgroups = jsonPayload.getJSONArray("groups");
 			for (int idx = 0; idx < jgroups.length(); idx++)
 			{
 				newGroup = new RssGroup(jgroups.getJSONObject(idx), this);
-				
+
 				// Merge with existing if post-initialization
 				RssGroup oldGroup = findGroupById(newGroup.id);
 				if (oldGroup != null)
@@ -521,7 +521,7 @@ public class MeltdownApp extends Application
 						Log.d(TAG, "Title changed, now " + newGroup.title);
 						oldGroup.title = newGroup.title;
 					}
-					
+
 					if (!oldGroup.feed_ids.containsAll(newGroup.feed_ids))
 					{
 						Log.d(TAG, "Feed IDs have changed");
@@ -530,35 +530,35 @@ public class MeltdownApp extends Application
 				}
 				else
 				{
-					// Log.d(TAG, "Doing initial groups allocation for " + newGroup.title);					
+					// Log.d(TAG, "Doing initial groups allocation for " + newGroup.title);
 					groups.add(newGroup);
 				}
-			}			
+			}
 			saveFeedsGroupsData(jsonPayload);
-			
-		} catch (JSONException e) 
+
+		} catch (JSONException e)
 		{
 			e.printStackTrace();
-		}		
-		
+		}
+
 		Log.i(TAG, groups.size() + " groups found");
 	}
-	
+
 	// Save RSS items parsed from payload, return number saved.
 	public int saveItemsData(String payload)
 	{
 		JSONArray jitems;
 		RssItem this_item;
-		
+
 		if (payload == null)
 			return 0;
-		
+
 		Context ctx = getApplicationContext();
-		
+
 		try
 		{
 			JSONObject jdata = new JSONObject(payload);
-			
+
 			jitems = jdata.getJSONArray("items");
 			// Check ending condition(s)
 			if (jitems.length() == 0)
@@ -566,30 +566,30 @@ public class MeltdownApp extends Application
 				Log.i(TAG, "No more items in feed!");
 				return -1;
 			}
-			
+
 			this.last_refresh_time = jdata.getLong("last_refreshed_on_time");
 			for (int idx = 0; idx < jitems.length(); idx++)
 			{
 				this_item = new RssItem(jitems.getJSONObject(idx));
 				// Save it to disk
 				this_item.saveToFile(ctx);
-				
+
 				// Remove the HTML for later loading if needed
 				this_item.dropHTML();
 
 				saveRssItem(this_item);
 			}
 			return jitems.length();
-		} catch (JSONException e) 
+		} catch (JSONException e)
 		{
 			e.printStackTrace();
-		}			
-		return 0;		
+		}
+		return 0;
 	}
-	
-	/* 
-	 * Save a story (aka item) into our data structures and cache file. Needs to lookup which 
-	 * group should hold the item, but we do that only once, and might look it up via group many 
+
+	/*
+	 * Save a story (aka item) into our data structures and cache file. Needs to lookup which
+	 * group should hold the item, but we do that only once, and might look it up via group many
 	 * times, so sorting it an ingress seems reasonable.
 	 */
 	private void saveRssItem(RssItem item)
@@ -598,15 +598,17 @@ public class MeltdownApp extends Application
 		if (group == null)
 		{
 			RssFeed feed = findFeedById(item.feed_id);
-			if (feed.is_spark) {
+			if (feed.is_spark)
+			{
 				Log.d(TAG, "Spark found for post ID " + item.id + " " + item.title);
 				group = findGroupById(SPARKS_ID);
-			} else {
+			} else
+			{
 				Log.d(TAG, "Orphan item! No group found for post ID " + item.id + " " + item.title);
 				group = findGroupById(ORPHAN_ID);
 			}
 		}
-		
+
 		// DDT
 		for (int idx = 0; idx < group.items.size(); idx++)
 		{
@@ -618,9 +620,9 @@ public class MeltdownApp extends Application
 		}
 		group.items.add(item);
 	}
-	
+
 	/*
-	 * I tried using the favicons as ActionBar headers, but there's scaling needed and I wasn't impressed. The 
+	 * I tried using the favicons as ActionBar headers, but there's scaling needed and I wasn't impressed. The
 	 * code is idle for now, but I think next I'll try a tweaked listview of items, with the favicon center left
 	 * on each story. Might look good and provide a visual cue as to source/author.
 	 */
@@ -628,32 +630,32 @@ public class MeltdownApp extends Application
 	{
 		JSONArray jitems;
 		Favicon this_item;
-		
+
 		if (payload == null)
 			return;
-		
+
 		try
 		{
 			JSONObject jdata = new JSONObject(payload);
-			
+
 			jitems = jdata.getJSONArray("favicons");
 			if (jitems.length() == 0)
 			{
 				Log.i(TAG, "No icons found!");
 				return;
 			}
-			
+
 			for (int idx = 0; idx < jitems.length(); idx++)
 			{
 				// Constructor does all the hard work for us.
 				this_item = new Favicon(jitems.getString(idx));
 				icons.add(this_item);
 			}
-		} catch (JSONException e) 
+		} catch (JSONException e)
 		{
 			e.printStackTrace();
-		}			
-		
+		}
+
 		// Now link feeds with icons
 		for (int idx = 0; idx < icons.size(); idx++)
 		{
@@ -662,7 +664,7 @@ public class MeltdownApp extends Application
 				feed.icon = icons.get(idx);
 		}
 	}
-	
+
 	// We display the groups in alphabetical order. Seems a sensible default.
 	// See http://stackoverflow.com/questions/5815423/sorting-arraylist-in-android-in-alphabetical-order-case-insensitive
 	protected void sortGroupsByName()
@@ -671,9 +673,9 @@ public class MeltdownApp extends Application
 			public int compare(RssGroup r1, RssGroup r2) {
 				return String.CASE_INSENSITIVE_ORDER.compare(r1.title, r2.title);
 			}
-		});		
-	}	
-	
+		});
+	}
+
 	// Newest first - reversed order by comparing 2 to 1
 	// http://stackoverflow.com/questions/5894818/how-to-sort-arraylistlong-in-java-in-decreasing-order
 	protected void sortItemsByDate()
@@ -687,7 +689,7 @@ public class MeltdownApp extends Application
 			});
 		}
 	}
-	
+
 	/*
 	 * Start the Downloader, and add it to  (approximate) via alarm service. We use
 	 * inexact to save battery life; the fetches can be off but that's fine.
@@ -698,25 +700,25 @@ public class MeltdownApp extends Application
 		Intent sIntent = new Intent(this, Downloader.class);
 		sIntent.putExtra(FIRST_RUN, true);
 		startService(sIntent);
-		
+
 		Log.i(TAG, "Setting up periodic updates...");
-		
-    	Context ctx = getApplicationContext();
+
+		Context ctx = getApplicationContext();
 		Intent svc_intent = new Intent(ctx, Downloader.class);
 		svc_intent.putExtra("first_run", false);
 		pendingIntent = PendingIntent.getService(ctx, 0, svc_intent, PendingIntent.FLAG_UPDATE_CURRENT);
 		AlarmManager am = (AlarmManager) ctx.getSystemService(Context.ALARM_SERVICE);
-		am.setInexactRepeating(AlarmManager.ELAPSED_REALTIME, SystemClock.elapsedRealtime(), 
+		am.setInexactRepeating(AlarmManager.ELAPSED_REALTIME, SystemClock.elapsedRealtime(),
 				AlarmManager.INTERVAL_FIFTEEN_MINUTES, pendingIntent);
 
-		Log.d(TAG, "Score update service scheduled for execution");		
+		Log.d(TAG, "Score update service scheduled for execution");
 	}
-	
+
 	protected void sweepReadFromGroup(RssGroup group)
 	{
 		if (group == null)
 			return;
-		
+
 		List<RssItem> trimmedList = new ArrayList<RssItem>();
 		for (int idx = 0; idx < group.items.size(); idx++)
 		{
@@ -726,9 +728,9 @@ public class MeltdownApp extends Application
 			else
 				trimmedList.add(item);
 		}
-		
+
 		group.items = trimmedList;
-		
+
 		// DDT
 		for (int idx = 0; idx < group.items.size(); idx++)
 		{
@@ -736,9 +738,9 @@ public class MeltdownApp extends Application
 			if (item.is_read)
 				Log.e(TAG, "ERROR Item not removed properly!!!! " + item.title);
 		}
-		//Log.d(TAG, group.items.size() + " items left in " + group.title + " after read sweep");		
+		//Log.d(TAG, group.items.size() + " items left in " + group.title + " after read sweep");
 	}
-	
+
 	// TODO remove me before release!
 	protected void checkForDuplicates()
 	{
@@ -758,9 +760,9 @@ public class MeltdownApp extends Application
 			}
 		}
 	}
-	
+
 	/*
-	 * Iterate over the items, remove any that are marked read. GC, called by Downloader 
+	 * Iterate over the items, remove any that are marked read. GC, called by Downloader
 	 * and when exiting a group view. Mark and sweep GC, very basic.
 	 */
 	protected void sweepReadItems()
@@ -768,7 +770,7 @@ public class MeltdownApp extends Application
 		for (int gidx = 0; gidx < groups.size(); gidx++)
 			sweepReadFromGroup(groups.get(gidx));
 	}
-		
+
 	/* The unread_items_ids returns an N-length array of items that are unread on the server. We have to:
 	 * parse the list
 	 * match what we have locally
@@ -776,18 +778,18 @@ public class MeltdownApp extends Application
 	 * cull local items not on the list
 	 * 
 	 * This routine is the heart of Meltdown's synchronization with the server.
-	 */	
+	 */
 	protected void syncUnreadPosts(Boolean reload_from_disk)
 	{
 		List<Integer> serverItemIDs = fetchUnreadItemsIDs();
-		
-		Log.d(TAG, serverItemIDs.size() + " unread items found on server.");	
+
+		Log.d(TAG, serverItemIDs.size() + " unread items found on server.");
 		if (serverItemIDs.size() == 0)
 			return;
-		
+
 		// DDT
 		checkForDuplicates();
-		
+
 		if (reload_from_disk)
 			reloadItemsFromDisk(serverItemIDs);
 		else
@@ -796,7 +798,7 @@ public class MeltdownApp extends Application
 			for (int idx = 0; idx < groups.size(); idx++)
 			{
 				RssGroup grp = groups.get(idx);
-				
+
 				// This pass removes local items that are gone from the server - read elsewhere, most likely.
 				for (int i = 0; i < grp.items.size(); i++)
 				{
@@ -812,7 +814,7 @@ public class MeltdownApp extends Application
 
 		// DDT
 		checkForDuplicates();
-		
+
 		// Now we're looking for posts on the server we *don't* have yet.
 		List<Integer> itemsToGet = new ArrayList<Integer>();
 
@@ -821,11 +823,11 @@ public class MeltdownApp extends Application
 			if (findPostById(serverItemIDs.get(idx)) == null)
 				itemsToGet.add(serverItemIDs.get(idx));
 		}
-		
+
 		Log.i(TAG, itemsToGet.size() + " items to retrieve");
 		if (itemsToGet.size() == 0)
 			return;
-		
+
 		// Could use size of newItems for progress dialog. Someday. Maybe a 'persistent activity' notification? TODO.
 		final int PER_FETCH = 50;
 		final int num_fetches = (int) Math.ceil(itemsToGet.size() / PER_FETCH) + 1;
@@ -834,16 +836,16 @@ public class MeltdownApp extends Application
 			int left_index = idx * PER_FETCH;
 			int right_index = Math.min((idx + 1) * PER_FETCH, itemsToGet.size());
 			Log.d(TAG, "On run " + idx + " pulling from " + left_index + " to " + (right_index - 1) + " of " + itemsToGet.size());
-			
+
 			List<Integer> ids = itemsToGet.subList(left_index, right_index);
 			String payload = xcvr.fetchListOfItems(ids);
 			saveItemsData(payload);
 		}
-		
+
 		// DDT
-		checkForDuplicates();		
+		checkForDuplicates();
 	}
-	
+
 	/*
 	 * We have group->feed and item->feed mappings, need to make feed->group
 	 */
@@ -853,6 +855,12 @@ public class MeltdownApp extends Application
 		{
 			RssFeed feed = feeds.get(idx);
 			RssGroup group = findGroupHoldingFeed(feed.id);
+			if(feed.is_spark)
+			{
+				Log.e(TAG, "Feed " + feed.title + " is a spark.");
+				// don't add sparks to any groups
+				continue;
+			}
 			if (group == null)
 			{
 				Log.e(TAG, "No group found for feed " + feed.title);
@@ -861,9 +869,8 @@ public class MeltdownApp extends Application
 			// Skip duplicates
 			if (feed.groups.contains(group.id))
 				continue;
-			
+
 			feed.groups.add(group.id);
 		}
 	}
 }
- 

--- a/src/net/phfactor/meltdown/RssFeed.java
+++ b/src/net/phfactor/meltdown/RssFeed.java
@@ -8,13 +8,13 @@ import org.json.JSONObject;
 
 import android.util.Log;
 
-/*
+/**
  * Simple representation of an RSS feed.
  */
-public class RssFeed 
+public class RssFeed
 {
 	static final String TAG = "MeltdownRssFeed";
-	
+
 	public  String site_url;
 	public  String url;
 	public  String title;
@@ -23,29 +23,29 @@ public class RssFeed
 	public  Boolean is_spark;
 	public  long last_updated_on_time;
 	public Favicon icon;
-	
+
 	// Derived reverse index
 	public List<Integer> groups;
-	
+
 	public RssFeed(JSONObject feed)
 	{
 		try
 		{
 			//Log.d(TAG, feed.toString());
 			this.icon = null;
-			
+
 			this.site_url = feed.getString("site_url");
 			this.url = feed.getString("url");
 			this.title = feed.getString("title");
 			this.id = feed.getInt("id");
 			this.favicon_id = feed.getInt("favicon_id");
-			this.is_spark = (feed.getInt("is_spark") == 0);
-			this.last_updated_on_time = feed.getLong("last_updated_on_time");			
+			this.is_spark = (feed.getInt("is_spark") != 0);
+			this.last_updated_on_time = feed.getLong("last_updated_on_time");
 			this.groups = new ArrayList<Integer>();
-			
-		}catch (JSONException je)
+
+		} catch (JSONException je)
 		{
-			Log.e(TAG, "Unable to parse JSON feed!", je);			
+			Log.e(TAG, "Unable to parse JSON feed!", je);
 		}
 	}
 }


### PR DESCRIPTION
This change will create a separate group for _Sparks_ and remove them from the _Orphaned Feeds_ group.

As I understand _Sparks_, they are not real feeds that you read every day but their items still contribute to the _Hot_ items. It is confusing if they show up mixed with my feed items.

I tried not to mess too much with your codestyle, but I did a little cleanup in the files that I changes. Mostly removing trailing spaces, organizing imports - nothing destructive.
