### PR TITLE
Make a preference to disable Sparks

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -62,4 +62,5 @@
         <item>43200000</item>
         <item>86400000</item>
     </string-array>
+    <string name="prefBoolDisableSpark">Disable loading of Sparks</string>
 </resources>

--- a/res/xml/prefs.xml
+++ b/res/xml/prefs.xml
@@ -2,5 +2,6 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <ListPreference android:entryValues="@array/intervalValues" android:summary="@string/prefIntSummary"
         android:title="@string/prefIntTitle" android:key="interval" android:entries="@array/intervals" />
+    <CheckBoxPreference android:title="@string/prefBoolDisableSpark" android:key="disable_sparks"/>
     
 </PreferenceScreen>

--- a/src/net/phfactor/meltdown/ConfigFile.java
+++ b/src/net/phfactor/meltdown/ConfigFile.java
@@ -19,10 +19,11 @@ public class ConfigFile
 	private static final String P_TOKEN = "token";
 	private static final String P_POST_URL = "postUrl";
 	private static final String P_INTERVAL = "interval"; // Must match preference key
-	
+	private static final String P_DISABLE_SPARKS = "disable_sparks";
+
 	private SharedPreferences prefs;
 	private SharedPreferences.Editor editor;
-	
+
 	public ConfigFile(Context ctx)
 	{
 		this.prefs = PreferenceManager.getDefaultSharedPreferences(ctx);
@@ -72,7 +73,11 @@ public class ConfigFile
 			return false;
 		return true;
 	}
-	
+
+	public boolean getDisableSparks() {
+		return prefs.getBoolean(P_DISABLE_SPARKS, false);
+	}
+
 	public String getToken()
 	{
 		return prefs.getString(P_TOKEN, null);

--- a/src/net/phfactor/meltdown/MeltdownApp.java
+++ b/src/net/phfactor/meltdown/MeltdownApp.java
@@ -630,6 +630,7 @@ public class MeltdownApp extends Application implements OnSharedPreferenceChange
 	 */
 	private void saveRssItem(RssItem item)
 	{
+		Log.d(TAG, "Updating item " + item);
 		RssGroup group = findGroupForItem(item);
 		if (group == null)
 		{
@@ -637,9 +638,9 @@ public class MeltdownApp extends Application implements OnSharedPreferenceChange
 			if (feed == null)
 			{
 				Log.d(TAG, "Orphan item! No group found for post ID " + item.id + " " + item.title);
-				group = findGroupById(ORPHAN_ID);				
+				group = findGroupById(ORPHAN_ID);
 			}
-			else if (feed.is_spark)
+			else if (feed.is_spark && !configFile.getDisableSparks())
 			{
 				Log.d(TAG, "Spark found for post ID " + item.id + " " + item.title);
 				group = findGroupById(SPARKS_ID);

--- a/src/net/phfactor/meltdown/MeltdownApp.java
+++ b/src/net/phfactor/meltdown/MeltdownApp.java
@@ -647,7 +647,14 @@ public class MeltdownApp extends Application implements OnSharedPreferenceChange
 			} 
 		}
 
-		group.items.add(item);
+		if(group != null && group.items != null)
+		{
+			group.items.add(item);
+		}
+		else
+		{
+			Log.w(TAG, "Something went wrong while saving item " + item);
+		}
 	}
 
 	/*

--- a/src/net/phfactor/meltdown/RssGroup.java
+++ b/src/net/phfactor/meltdown/RssGroup.java
@@ -33,19 +33,19 @@ public class RssGroup
 			this.items = new ArrayList<RssItem>();
 		} catch (JSONException e) 
 		{
-			Log.e(TAG, "Unable to parse JSON feed!");			
+			Log.e(TAG, "Unable to parse JSON feed!");
 			e.printStackTrace();
 		}
-	}	
-	
-	public RssGroup(String ttl, int id)
+	}
+
+	public RssGroup(String title, int id)
 	{
-		this.title = ttl;
+		this.title = title;
 		this.id = id;
 		this.feed_ids = new ArrayList<Integer>();
 		this.items = new ArrayList<RssItem>(); 
 	}
-	
+
 	public void clearItems()
 	{
 		this.items = new ArrayList<RssItem>();


### PR DESCRIPTION
I am not reading Sparks and I keep them only to populate my Hot Items. Now there is a preference to disable Sparks in Meltdown.

I'm not sure if the Fever API allows to prevent loading the Sparks, that would be even better. This will still download them, but not show/save them in Meltdown.

Does it cause duplicate downloads? Maybe I should issue an additional POST request to mark Sparks as read.

The POST request has to set the following values
- mark=group
- as=read
- id=-1
- before=UNIX_TIMESTAMP
